### PR TITLE
Allow setting connection string using environment variable DATA_SOURC…

### DIFF
--- a/pgbouncer_exporter.go
+++ b/pgbouncer_exporter.go
@@ -27,11 +27,19 @@ const (
 	</html>`
 )
 
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
 func main() {
 	var (
 		showVersion             = flag.Bool("version", false, "Print version information.")
 		listenAddress           = flag.String("web.listen-address", ":9127", "Address on which to expose metrics and web interface.")
-		connectionStringPointer = flag.String("pgBouncer.connectionString", "postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable", "Connection string for accessing pgBouncer.")
+		connectionStringPointer = flag.String("pgBouncer.connectionString", "postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable",
+			"Connection string for accessing pgBouncer. Can also be set using environment variable DATA_SOURCE_NAME")
 		metricsPath             = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	)
 
@@ -42,7 +50,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	connectionString := *connectionStringPointer
+	connectionString := getEnv("DATA_SOURCE_NAME", *connectionStringPointer)
 	exporter := NewExporter(connectionString, namespace)
 	prometheus.MustRegister(exporter)
 


### PR DESCRIPTION
…E_NAME

It is safer to use DATA_SOURCE_NAME than pgBouncer.connectionString, to
prevent the password from showing up in the output of ps